### PR TITLE
fix: remove duplicate ContactForm imports and render call

### DIFF
--- a/src/components/Form/ContactForm.js
+++ b/src/components/Form/ContactForm.js
@@ -1,6 +1,4 @@
-import React from 'react';
-import Component from 'react';
-import ReactDOM from 'react-dom';
+import React, { Component } from 'react';
 
 const encode = (data) => {
   return Object.keys(data)
@@ -8,7 +6,7 @@ const encode = (data) => {
       .join("&");
 }
 
-class ContactForm extends React.Component {
+class ContactForm extends Component {
   constructor(props) {
     super(props);
     this.state = { name: "",company: "", phone: "", email: "", message: "" };
@@ -110,5 +108,5 @@ class ContactForm extends React.Component {
   }
 }
 
-ReactDOM.render(<ContactForm />, document.getElementById("root"));
 export default ContactForm;
+


### PR DESCRIPTION
## Summary
- fix ContactForm component imports and remove direct ReactDOM.render call

## Testing
- `npm test` (fails: react-scripts: not found)
- `npm install react-scripts@1.1.4` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a2549fcf6c8321bdc063a200c74e98